### PR TITLE
Remove outdated setting

### DIFF
--- a/config/hpc2n+c3se-settings.py
+++ b/config/hpc2n+c3se-settings.py
@@ -693,7 +693,7 @@ site_configuration = {
             'cxx': 'g++',
             'ftn': 'gfortran',
             'target_systems': ['kebnekaise'],
-	    'features': ['cuda'],
+            'features': ['cuda'],
         },
         {
             'name': 'foss_with_cuda',
@@ -702,7 +702,7 @@ site_configuration = {
             'cxx': 'g++',
             'ftn': 'gfortran',
             'target_systems': ['alvis'],
-	    'features': ['cuda'],
+            'features': ['cuda'],
         },
     ],
     'logging': [
@@ -797,7 +797,6 @@ site_configuration = {
             'check_search_path': ['checks/'],
             'check_search_recursive': True,
             'remote_detect': True,
-	    'reframe_module': 'ReFrame',
         },
     ],
 }


### PR DESCRIPTION
`reframe_module` has been deprecated as of:
https://github.com/reframe-hpc/reframe/pull/946

in recent versions (tested with 4.0.1 and 4.2.0), keeping this configuration
leads to an error:

```
ERROR: failed to load configuration: could not validate configuration files: 
'['<builtin>', 'config/hpc2n+c3se-settings.py']': 
Additional properties are not allowed ('reframe_module' was unexpected)
```

(also replaced tabs in the same file)
