### PR TITLE
Fix nvidia-smi check for Alvis

### DIFF
--- a/checks/system/nvidia/nvidia_smi_check.py
+++ b/checks/system/nvidia/nvidia_smi_check.py
@@ -13,7 +13,7 @@ from reframe.core.backends import getlauncher
 @rfm.simple_test
 class nvidia_smi_check(rfm.RunOnlyRegressionTest):
     gpu_mode = parameter(['accounting', 'compute', 'ecc'])
-    valid_systems = ['alvis', 'kebnekaise']
+    valid_systems = ['+nvgpu']
     valid_prog_environs = ['builtin']
     executable = 'nvidia-smi'
     executable_opts = ['-a', '-d']


### PR DESCRIPTION
Set as draft as I don't know how is this for kebnekaise:

1. set valid systems to `+nvgpu` to exclude CPU nodes;
2. remove accounting checks, this is not used at least at Alvis.