### PR TITLE
C3SE numpy updates

### DIFF
--- a/checks/apps/python/numpy_check.py
+++ b/checks/apps/python/numpy_check.py
@@ -8,8 +8,10 @@ import reframe as rfm
 from hpctestlib.python.numpy.numpy_ops import numpy_ops_check
 from reframe.utility import find_modules
 
-class snic_numpy_test(numpy_ops_check):
+@rfm.simple_test
+class numpy_check(numpy_ops_check):
     valid_prog_environs = ['builtin']
+    valid_systems = ['alvis', 'kebnekaise']
     num_tasks_per_node = 1
     use_multithreading = False
     all_ref = {
@@ -60,10 +62,12 @@ class snic_numpy_test(numpy_ops_check):
     maintainers = ['RS', 'TR', 'AS']
 
     @run_after('init')
-    def process_module_info(self):
-        s, e, m = self.module_info
-        self.valid_prog_environs = [e]
-        self.modules = [m]
+    def set_modules(self):
+        module = {
+            'kebnekaise': [],
+            'alvis': ['SciPy-bundle/2024.05-gfbf-2024a'],
+        }
+        self.modules = module.get(self.current_system.name, [])
 
     @run_after('setup')
     def set_num_cpus_per_task(self):
@@ -80,13 +84,3 @@ class snic_numpy_test(numpy_ops_check):
         self.reference = {
             pname: self.all_ref[f'{arch}@{num_cores}c']
         }
-
-@rfm.simple_test
-class c3se_numpy_test(snic_numpy_test):
-    module_info = parameter(find_modules('SciPy-bundle', { r'.*': 'builtin' }))
-    valid_systems = ['alvis']
-
-@rfm.simple_test
-class hpc2n_numpy_test(snic_numpy_test):
-    module_info = parameter(find_modules('SciPy-bundle'))
-    valid_systems = ['kebnekaise']

--- a/checks/apps/python/numpy_check.py
+++ b/checks/apps/python/numpy_check.py
@@ -43,6 +43,20 @@ class numpy_check(numpy_ops_check):
             'eigendec': (4.14, None, 0.05, 's'),
             'inv': (0.16, None, 0.05, 's'),
         },
+        'cascadelake@16c': {
+            'dot': (0.16, None, 0.05, 's'),
+            'svd': (0.64, None, 0.05, 's'),
+            'cholesky': (0.13, None, 0.05, 's'),
+            'eigendec': (4.96, None, 0.05, 's'),
+            'inv': (0.21, None, 0.05, 's'),
+        },
+        'cascadelake@32c': {
+            'dot': (0.16, None, 0.05, 's'),
+            'svd': (0.64, None, 0.05, 's'),
+            'cholesky': (0.13, None, 0.05, 's'),
+            'eigendec': (4.96, None, 0.05, 's'),
+            'inv': (0.21, None, 0.05, 's'),
+        },
         'skylake@14c': {
             'dot': (0.3, None, 0.05, 's'),
             'svd': (0.35, None, 0.05, 's'),
@@ -56,6 +70,13 @@ class numpy_check(numpy_ops_check):
             'cholesky': (0.1, None, 0.05, 's'),
             'eigendec': (4.14, None, 0.05, 's'),
             'inv': (0.16, None, 0.05, 's'),
+        },
+        'icelake@64c': {
+            'dot': (0.19, None, 0.05, 's'),
+            'svd': (1.29, None, 0.05, 's'),
+            'cholesky': (0.46, None, 0.05, 's'),
+            'eigendec': (9.56, None, 0.05, 's'),
+            'inv': (0.36, None, 0.05, 's'),
         },
     }
     tags = {'production'}


### PR DESCRIPTION
Draft as this will not work for kebnekaise and I'm not sure about all the reference numbers, though I have questions already:

1. `find_modules` seems very slow on alvis (3min just to list the available tests if I keep it), [other site](https://github.com/reframe-hpc/cscs-reframe-tests/blob/main/checks/apps/python/numpy_check.py) doesn't seem to use that for numpy, so I want to remove that (I don't know which module to use for kebnekaise);
2. I want to add some reference numbers for the missing partitions, though I'm not sure how those numbers are decided, currently I just run several rounds and set the reference number to the worst case.