### PR TITLE
Move PYTHONPATH hack to checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@ Simple use instructions:
  - clone the repo into this directory
  - cd hpc2n-reframe-tests
  - Load ReFrame module (4.2 or later)
- - PYTHONPATH=$PWD/checks:$PYTHONPATH
  - list all available tests:
    reframe -C config/hpc2n+c3se-settings.py -l
 
 To run maintenance tests:
 reframe -C config/hpc2n+c3se-settings.py -r -t maintenance
-This will run the tests that are tagged with maintenance on all node types (reframe paritions).
+This will run the tests that are tagged with maintenance on all node types (reframe partitions).
 
 To run maintenance test on a specific node:
 reframe -C config/hpc2n+c3se-settings.py -r -t maintenance --system alvis:<partition> -J nodelist=alvisx-y

--- a/checks/apps/tensorflow/tf2_horovod_check.py
+++ b/checks/apps/tensorflow/tf2_horovod_check.py
@@ -9,6 +9,8 @@ import reframe.utility.osext as osext
 
 from hpctestlib.ml.tensorflow.horovod import tensorflow_cnn_check
 
+import os,sys
+sys.path.append(os.path.abspath(os.path.join(__file__, '../../..')))
 import microbenchmarks.gpu.hooks as hooks
 
 REFERENCE_SMALL_PERFORMANCE = {

--- a/checks/apps/tensorflow/tf2_horovod_check.py
+++ b/checks/apps/tensorflow/tf2_horovod_check.py
@@ -4,12 +4,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import contextlib
+import os
+import sys
 import reframe as rfm
 import reframe.utility.osext as osext
 
 from hpctestlib.ml.tensorflow.horovod import tensorflow_cnn_check
 
-import os,sys
 sys.path.append(os.path.abspath(os.path.join(__file__, '../../..')))
 import microbenchmarks.gpu.hooks as hooks
 

--- a/checks/apps/tensorflow/tf2_horovod_check.py
+++ b/checks/apps/tensorflow/tf2_horovod_check.py
@@ -5,9 +5,9 @@
 
 import contextlib
 import os
-import sys
 import reframe as rfm
 import reframe.utility.osext as osext
+import sys
 
 from hpctestlib.ml.tensorflow.horovod import tensorflow_cnn_check
 

--- a/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
+++ b/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
@@ -9,6 +9,7 @@ import sys
 import reframe as rfm
 from hpctestlib.microbenchmarks.gpu.memory_bandwidth import *
 
+sys.path.append(os.path.abspath(os.path.join(__file__, '../../..')))
 import microbenchmarks.gpu.hooks as hooks
 
 

--- a/checks/system/nvidia/nvidia_smi_check.py
+++ b/checks/system/nvidia/nvidia_smi_check.py
@@ -6,6 +6,9 @@
 import reframe as rfm
 import reframe.utility.sanity as sn
 import reframe.utility.typecheck as typ
+
+import os,sys
+sys.path.append(os.path.abspath(os.path.join(__file__, '../../..')))
 import microbenchmarks.gpu.hooks as hooks
 
 from reframe.core.backends import getlauncher

--- a/checks/system/nvidia/nvidia_smi_check.py
+++ b/checks/system/nvidia/nvidia_smi_check.py
@@ -3,15 +3,16 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
+import sys
 import reframe as rfm
 import reframe.utility.sanity as sn
 import reframe.utility.typecheck as typ
 
-import os,sys
+from reframe.core.backends import getlauncher
+
 sys.path.append(os.path.abspath(os.path.join(__file__, '../../..')))
 import microbenchmarks.gpu.hooks as hooks
-
-from reframe.core.backends import getlauncher
 
 @rfm.simple_test
 class nvidia_smi_check(rfm.RunOnlyRegressionTest):

--- a/checks/system/nvidia/nvidia_smi_check.py
+++ b/checks/system/nvidia/nvidia_smi_check.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import sys
 import reframe as rfm
 import reframe.utility.sanity as sn
 import reframe.utility.typecheck as typ
+import sys
 
 from reframe.core.backends import getlauncher
 


### PR DESCRIPTION
Taken from the [CSCS setup](https://github.com/eth-cscs/cscs-reframe-tests/blob/f8a1d806cc2f582e4fb3d4ffff5c83c1a551872d/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py#L12), I think it's less easier this way.