### PR TITLE
Import cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Simple use instructions:
  - clone the repo into this directory
  - cd hpc2n-reframe-tests
  - Load ReFrame module (4.2 or later)
- - PYTHONPATH=$PWD/checks:$PYTHONPATH
  - list all available tests:
    reframe -C config/hpc2n+c3se-settings.py -l
 

--- a/checks/apps/tensorflow/tf2_horovod_check.py
+++ b/checks/apps/tensorflow/tf2_horovod_check.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import contextlib
 import reframe as rfm
 import reframe.utility.osext as osext
 

--- a/checks/apps/tensorflow/tf2_horovod_check.py
+++ b/checks/apps/tensorflow/tf2_horovod_check.py
@@ -9,7 +9,7 @@ import reframe.utility.osext as osext
 
 from hpctestlib.ml.tensorflow.horovod import tensorflow_cnn_check
 
-import microbenchmarks.gpu.hooks as hooks
+hooks = rfm.utility.import_module("...microbenchmarks.gpu.hooks")
 
 REFERENCE_SMALL_PERFORMANCE = {
     'alvis:8xT4': {

--- a/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
+++ b/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
-import sys
-
 import reframe as rfm
 
 from hpctestlib.microbenchmarks.gpu.memory_bandwidth import *

--- a/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
+++ b/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
@@ -7,7 +7,7 @@ import reframe as rfm
 
 from hpctestlib.microbenchmarks.gpu.memory_bandwidth import *
 
-hooks = rfm.utility.import_module("..hooks")
+hooks = rfm.utility.import_module("....microbenchmarks.gpu.hooks")
 
 class SystemConfigHPC2N(rfm.RegressionMixin):
     # Inject external hooks

--- a/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
+++ b/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
@@ -7,10 +7,10 @@ import os
 import sys
 
 import reframe as rfm
+
 from hpctestlib.microbenchmarks.gpu.memory_bandwidth import *
 
-import microbenchmarks.gpu.hooks as hooks
-
+hooks = rfm.utility.import_module("..hooks")
 
 class SystemConfigHPC2N(rfm.RegressionMixin):
     # Inject external hooks

--- a/checks/system/nvidia/nvidia_smi_check.py
+++ b/checks/system/nvidia/nvidia_smi_check.py
@@ -6,9 +6,10 @@
 import reframe as rfm
 import reframe.utility.sanity as sn
 import reframe.utility.typecheck as typ
-import microbenchmarks.gpu.hooks as hooks
 
 from reframe.core.backends import getlauncher
+
+hooks = rfm.utility.import_module("...microbenchmarks.gpu.hooks")
 
 @rfm.simple_test
 class nvidia_smi_check(rfm.RunOnlyRegressionTest):


### PR DESCRIPTION
1. use rfm.utility for relative imports
2. some unused import cleanup

I think this beats #9